### PR TITLE
Update to ansi_term 0.12.1

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,4 +10,4 @@ homepage = "https://github.com/joshtriplett/colorparse"
 description = "Parse color configuration strings (in Git syntax) into ansi_term::Style objects."
 
 [dependencies]
-ansi_term = "0.9.0"
+ansi_term = "0.12.1"


### PR DESCRIPTION
This patch updates the version of `ansi_term`. `cargo test` finished with no errors.

The update is to avoid using multiple versions of `ansi_term` in a project with `lscolors` and `colorparse`:

```console
$ cargo add colorparse
…

$ cargo add lscolors
…

$ cargo build
…

$ cargo tree --duplicates
ansi_term v0.9.0
└── colorparse v2.0.1
    └── summer v0.1.0 (/source)

ansi_term v0.12.1
└── lscolors v0.7.1
    └── summer v0.1.0 (/source)
```
